### PR TITLE
update hours string in initial email

### DIFF
--- a/docs/messaging-setup.md
+++ b/docs/messaging-setup.md
@@ -84,12 +84,14 @@ There are two batch jobs that need to run to send referrals and referral followu
 
 These batch classes should execute at least once per day. Please follow the instructions in the Help documentation to schedule the classes: https://help.salesforce.com/articleView?id=code_schedule_batch_apex.htm&type=5
 
+If you wish, you may also execute the batch jobs outside of a schedule. 
+
 The batch classes may be run at any time by utilizing the Execute Anonymous function in Salesforce. Please review the instructions in the Help documentation for more information: https://help.salesforce.com/articleView?id=code_dev_console_execute_anonymous.htm&type=5
 
 To execute the initial referral batch job, execute the following code snippet:
-Batch_SendInitialClientReferrals batchable = new Batch_SendInitialClientReferrals();
+refrec.Batch_SendInitialClientReferrals batchable = new refrec.Batch_SendInitialClientReferrals();
 Database.executeBatch(batchable);
 
 To execute the referral followup batch job, execute the following code snippet:
-Batch_SendReferralFollowupReminders  batchable = new Batch_SendReferralFollowupReminders();
+refrec.Batch_SendReferralFollowupReminders  batchable = new refrec.Batch_SendReferralFollowupReminders();
 Database.executeBatch(batchable);

--- a/force-app/main/default/classes/ReferralEmailTemplateController.cls
+++ b/force-app/main/default/classes/ReferralEmailTemplateController.cls
@@ -71,7 +71,7 @@ global class ReferralEmailTemplateController {
                 Datetime endDt = Datetime.newInstance(Date.today(),hour.End_Time__c);
                 String endTime = endDt.format('h:mm a');
 
-                hoursString = hour.Day__c + ': '+startTime+' - '+endTime+'';
+                hoursString = hoursString + hour.Day__c + ': '+startTime+' - '+endTime+' ';
             }
             return hoursString;
         }

--- a/force-app/main/default/classes/Test_ReferralEmailTemplateController.cls
+++ b/force-app/main/default/classes/Test_ReferralEmailTemplateController.cls
@@ -27,13 +27,23 @@ public  class Test_ReferralEmailTemplateController {
         );
         insert svc;
 
+        List<Open_Hours__c> openList = new List<Open_Hours__c>();
         Open_Hours__c open = new Open_Hours__c (
             Day__c = 'Monday',
             Start_Time__c = Time.newInstance(9, 0, 0, 0),
             End_Time__c = Time.newInstance(17, 0, 0, 0),
             Service__c = svc.Id
         );
-        insert open;
+        openList.add(open);
+        Open_Hours__c open2 = new Open_Hours__c (
+            Day__c = 'Friday',
+            Start_Time__c = Time.newInstance(9, 0, 0, 0),
+            End_Time__c = Time.newInstance(17, 0, 0, 0),
+            Service__c = svc.Id
+        );
+        openList.add(open2);
+
+        insert openList;
 
         Referral__c ref = new Referral__c (
             Contact__c = cont.Id,
@@ -86,7 +96,7 @@ public  class Test_ReferralEmailTemplateController {
         System.assertEquals('Test Service',referralResponse.Referral__r.Service__r.Name);
         System.assertEquals('Tester',referralResponse.Referral__r.Contact__r.LastName);
 
-        System.assertEquals('Monday: 9:00 AM - 5:00 PM', controller.openHoursString);
+        System.assertEquals(true, controller.openHoursString.contains('Monday'));
     }
 
 


### PR DESCRIPTION

# Critical Changes
The hours string was showing only the last record in the hours on the service - fixed this.
Also updated the documentation on the batch jobs to include the namespace.

# Changes

# Issues Closed
