### PR TITLE
Need Scoring class to be Global as part of release.

### DIFF
--- a/force-app/main/default/classes/Scoring.cls
+++ b/force-app/main/default/classes/Scoring.cls
@@ -1,4 +1,4 @@
-public with sharing class Scoring {
+global with sharing class Scoring {
   // Positive Weights
 
   // example metric: my referrals


### PR DESCRIPTION

# Critical Changes
Reverted the Scoring class to use a Global syntax.  Scoring is used in the release process for package installation.
# Changes

# Issues Closed
